### PR TITLE
Story Player - Only show Close button if the story has started

### DIFF
--- a/app/scenes/StoryPlayer.js
+++ b/app/scenes/StoryPlayer.js
@@ -153,9 +153,13 @@ class StoryPlayer extends Component {
                     </Text> :
                     null
                     }
-                    <TouchableOpacity style={styles.closeContainer} onPress={this.close.bind(this)}>
-                        <Text style={styles.closePlayer}>X</Text>
-                    </TouchableOpacity>
+                    {this.state.started ?
+                        /* Only show X if audio is loaded, otherwise if user hits X before screen pops but the audio still plays */
+                        <TouchableOpacity style={styles.closeContainer} onPress={this.close.bind(this)}>
+                            <Text style={styles.closePlayer}>X</Text>
+                        </TouchableOpacity> :
+                        null
+                    }
                 </View>
 
                 <View style={styles.buttonContainer}>


### PR DESCRIPTION
@pauwlsky Another!

Sort of similar to the previous PR, this prevents the 'Close' action on the Story Player from being fired before the story loads. If the user presses the X before the story starts, this could cause the player to pop back to the List page, but still have the audio playing.

I know doing stuff in render function is frowned on, so if you have any better ideas, let me know!