### PR TITLE
Story Player - not counting down correctly

### DIFF
--- a/app/components/story/StoryComponent.js
+++ b/app/components/story/StoryComponent.js
@@ -4,6 +4,7 @@ import Dimensions from 'Dimensions';
 import { Actions } from 'react-native-router-flux';
 import{ StoryReducer } from '../../reducers/story_reducer';
 import { store } from '../../index';
+import { formatDuration } from '../../core/story_core'
 
 
 
@@ -23,8 +24,7 @@ class StoryComponent extends Component {
             url: this.props.url,
             name: this.props.name,
             event_time: this.props.event_time,
-            event_location: this.props.event_location,
-            duration: this.props.duration
+            event_location: this.props.event_location
         });
     }
 
@@ -42,7 +42,7 @@ class StoryComponent extends Component {
                                     source={require('../../../img/play-arrow-chalk-red.png')}/>
                             </View>
                             <View style={styles.durationContainer}>
-                                <Text style={styles.soundLength}>{this.props.duration}</Text>
+                                <Text style={styles.soundLength}>{formatDuration(this.props.duration)}</Text>
                             </View>
                         </View>
                     </View>

--- a/app/core/story_core.js
+++ b/app/core/story_core.js
@@ -43,7 +43,7 @@ function sortStoriesByEvent(storiesArray) {
                 event.event_stories.push({
                     "public_url": story.public_url,
                     "timestamp": story.timestamp,
-                    "duration": formatDuration(story.length_in_seconds)
+                    "duration": story.length_in_seconds
                 });
             }
         });

--- a/app/scenes/StoryPlayer.js
+++ b/app/scenes/StoryPlayer.js
@@ -6,6 +6,7 @@ import RNFetchBlob from 'react-native-fetch-blob'
 import Sound from 'react-native-sound';
 import { Actions } from 'react-native-router-flux';
 import { store } from '../index'
+import { formatDuration } from '../core/story_core'
 
 
 class StoryPlayer extends Component {
@@ -15,13 +16,11 @@ class StoryPlayer extends Component {
             blob: null,
             path: ""
         };
-        var time = props.duration.split(':');
         this.state = {
             started: false,
             loading: true,
             playing: false,
-            minutes_remaingin: parseInt(time[0]),
-            seconds_remaining: parseInt(time[1])
+            seconds_remaining: -1
         };
         this.countDownId = null;
     }
@@ -45,7 +44,7 @@ class StoryPlayer extends Component {
                     if (error) {
                         console.log("StoryTeller::RNFetchBlob::CreateBlobErr:: " + error);
                     } else {
-                        this.setState({loading: false, length: this.sound.blob.getDuration()});
+                        this.setState({loading: false, seconds_remaining: this.sound.blob.getDuration().toFixed(0)});
                         setTimeout(this.play.bind(this), 1000)
                     }
                 });
@@ -72,13 +71,7 @@ class StoryPlayer extends Component {
         if (action === 'start') {
             this.countDownId = setInterval(() => {
                 if (this.state.seconds_remaining > 0) {
-                    this.setState({seconds_remaining: this.state.seconds_remaining - 1});
-                    if (this.state.seconds_remaining < 0 ) {
-                        this.setState({
-                            minutes_remaining: this.state.minutes_remaingin -1,
-                            seconds_remaining: 60
-                        });
-                    }
+                    this.setState({seconds_remaining: this.state.seconds_remaining - 1})
                 }
             }, 1000);
         } else {
@@ -149,7 +142,7 @@ class StoryPlayer extends Component {
                     </Text>
                     {this.state.started ?
                         <Text style={styles.whenLabel}>TIME REMAINING:{'\  '}
-                        <Text style={styles.location}>{this.state.minutes_remaingin.toString()}:{this.state.seconds_remaining.toString()}</Text>
+                        <Text style={styles.location}>{formatDuration(this.state.seconds_remaining)}</Text>
                     </Text> :
                     null
                     }


### PR DESCRIPTION
@pauwlsky PR number 3!

I noticed that any duration over a minute was not counting down properly, so I fixed it and simplified things a little bit. I've also included my reasoning, in case you have any questions.

1. Instead of passing in duration, get it from the story blob. 
- Why? Since the sound blob already has the duration info, thats one less piece of data that needs to get passed around.  
2. Dont call formatDuration when constructing event list. Only use it for display formatting. 
- Why? Storing raw seconds in the event object is more flexible than storing the formatted MM:SS value. Much easier to work with a single integer second value than a complex datetime value.
3. Dont keep track of minutes and seconds, only  use seconds and formatDuration().
 - Why? Mentioned above, basically figuring out how to display MM:SS from just seconds is much easier than essentially keeping track of 2 counters. Just keeping track of seconds vs. keeping track of MM and SS and then dropping 1 MM after 60 seconds. 

As an aside, I find dealing with date/time values is always a PITA. In the backend I always try to store and pass around date/times as UTC timestamps (32 bit integer counting up from the epoch time). I try to NEVER store formatted date values in any datastore. Unix time leaves no room for ambiguity that can happen especially when time zones come into play. I know you didn't ask, but I wish someone had told me this early in my career.  If i ever talk to much just tell me to STFU :)