### PR TITLE
separated reducers into two reducers

### DIFF
--- a/app/components/story/StoryComponent.js
+++ b/app/components/story/StoryComponent.js
@@ -2,8 +2,7 @@ import { View, Image, Text, TouchableOpacity} from 'react-native';
 import React, { Component } from 'react';
 import Dimensions from 'Dimensions';
 import { Actions } from 'react-native-router-flux';
-import{ StoryReducer } from '../../reducers/story_reducer';
-import { store } from '../../index';
+import { connect } from 'react-redux';
 import { formatDuration } from '../../core/story_core'
 
 
@@ -17,9 +16,7 @@ class StoryComponent extends Component {
 
 
     onPress() {
-        var state = store.getState();
-        clearTimeout(state.get('timeoutId'));
-
+        clearTimeout(this.props.timeoutId);
         Actions.StoryPlayer({
             url: this.props.url,
             name: this.props.name,
@@ -103,4 +100,10 @@ const styles = {
     }
 };
 
-export default StoryComponent;
+const mapStateToProps = (state) => {
+    return {
+        timeoutId: state.getIn(['sequences', 'timeoutId'])
+    }
+}
+
+export default connect(mapStateToProps)(StoryComponent);

--- a/app/core/sequence_core.js
+++ b/app/core/sequence_core.js
@@ -1,0 +1,7 @@
+export function setTimeoutId(state, timeoutId) {
+    return state.set('timeoutId', timeoutId);
+}
+
+export function setColorSequences(state, colorSequence) {
+    return state.set('colorSequence', colorSequence );
+}

--- a/app/core/story_core.js
+++ b/app/core/story_core.js
@@ -2,10 +2,6 @@ export function setStories(state, stories) {
     return state.set('stories', stories);
 }
 
-export function setTimeoutId(state, timeoutId) {
-    return state.set('timeoutId', timeoutId);
-}
-
 export function setFeaturedStories(state, featuredStories) {
     return state.set('featuredStories', featuredStories)
 }
@@ -21,6 +17,7 @@ export function fetchStories(pageNum) {
         return sortStoriesByEvent(resJson);
     })
 }
+
 
 export function fetchFeaturedStories() {
     var url = 'https://storybox-145021.appspot.com/api/audio/featured';

--- a/app/index.js
+++ b/app/index.js
@@ -2,12 +2,10 @@ import React, { Component } from 'react';
 import { View } from 'react-native';
 import {Provider} from 'react-redux';
 import { createStore} from 'redux';
-import StoryReducer from './reducers/story_reducer';
 import  Navigator  from './navigator/navigator';
 import {fetchStories, fetchFeaturedStories} from './core/story_core';
 
-export const store = createStore(StoryReducer);
-
+import store from './reducers/reducers'
 
 
 export default class App extends Component {

--- a/app/reducers/reducers.js
+++ b/app/reducers/reducers.js
@@ -1,0 +1,17 @@
+import {combineReducers} from 'redux-immutable';
+import { Map } from 'immutable';
+import { createStore } from 'redux';
+import stories from './story_reducer';
+import sequences from './sequence_reducer';
+
+
+const initialState = Map();
+const rootReducer = combineReducers({stories, sequences});
+
+function makeStore() {
+    return createStore(rootReducer, initialState);
+}
+
+const store = makeStore();
+
+export default store;

--- a/app/reducers/sequence_reducer.js
+++ b/app/reducers/sequence_reducer.js
@@ -1,0 +1,11 @@
+import {Map} from 'immutable';
+import  {setTimeoutId} from '../core/sequence_core';
+
+export default function (state = Map({}), action) {
+    switch(action.type) {
+        case 'SET_TIMEOUT_ID':
+            clearTimeout(state.get('timeoutId'));
+            return setTimeoutId(state, action.timeoutId);
+    }
+    return state;
+}

--- a/app/reducers/story_reducer.js
+++ b/app/reducers/story_reducer.js
@@ -1,14 +1,11 @@
 import {Map} from 'immutable';
-import {setStories, setTimeoutId, setFeaturedStories} from '../core/story_core';
+import {setStories, setFeaturedStories} from '../core/story_core';
 
 
 export default function(state = Map({}), action) {
   switch (action.type) {
     case 'SET_STORIES':
       return setStories(state, action.state);
-    case 'SET_TIMEOUT_ID':
-      clearTimeout(state.get('timeoutId'));
-      return setTimeoutId(state, action.timeoutId);
     case 'SET_FEATURED_STORIES':
       return setFeaturedStories(state, action.featuredStories);
   }

--- a/app/scenes/IntroAnimation.js
+++ b/app/scenes/IntroAnimation.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = (state) => {
     return {
-        stories: state.get('stories')
+        stories: state.getIn(['stories','stories'])
     }
 };
 

--- a/app/scenes/IntroText.js
+++ b/app/scenes/IntroText.js
@@ -52,7 +52,7 @@ const styles = StyleSheet.create({
 
 const mapStateToProps = (state) => {
     return {
-        stories: state.get('stories')
+        stories: state.getIn(['stories','stories'])
     }
 };
 

--- a/app/scenes/StoryDisplay.js
+++ b/app/scenes/StoryDisplay.js
@@ -6,7 +6,6 @@ import SideWindow from '../components/common/SideWindow';
 import Dimensions from 'Dimensions';
 import testJson from '../test.json';
 import { Actions } from 'react-native-router-flux';
-import { store } from '../index'
 import { fetchStories, cycleColorProperties } from '../core/story_core';
 import { Colors } from '../stylesheets/theme';
 
@@ -29,7 +28,7 @@ class StoryContainer extends Component {
     }
 
     renderFeaturedStoryList() {
-        return this.props.featuredStories.map((event, i) => <StoryList key={"featured-list-1"}
+        return this.props.featuredStories.map((event, i) => <StoryList key={i}
                                                                        event_time={event.event_time}
                                                                        event_location={"Featured Stories"}
                                                                        event_stories={event.event_stories}
@@ -45,19 +44,19 @@ class StoryContainer extends Component {
         var id = setTimeout(()=> {
             this.close()
         }, 120000);
-        store.dispatch({type: 'SET_TIMEOUT_ID', timeoutId: id});
+        this.props.dispatch({type: 'SET_TIMEOUT_ID', timeoutId: id});
     }
 
     previousPage() {
         this.setState({is_loading: true});
         if (this.state.page_number > 0) {
             fetchStories(this.state.page_number - 1).done((stories) => {
-                store.dispatch({type: 'SET_STORIES', state: stories});
+                this.props.dispatch({type: 'SET_STORIES', state: stories});
                 this.setState({page_number: this.state.page_number - 1, is_loading: false});
             });
         } else {
             fetchStories().done((stories) => {
-                store.dispatch({type: 'SET_STORIES', state: stories});
+                this.props.dispatch({type: 'SET_STORIES', state: stories});
                 this.setState({page_number: 0, is_loading: false});
             });
         }
@@ -69,7 +68,7 @@ class StoryContainer extends Component {
             if (stories.length === 0) {
                 return this.setState({is_loading: false});
             }
-            store.dispatch({type: 'SET_STORIES', state: stories});
+            this.props.dispatch({type: 'SET_STORIES', state: stories});
             this.setState({page_number: this.state.page_number + 1, is_loading: false});
         });
     }
@@ -182,8 +181,8 @@ const styles = {
 
 const mapStateToProps = (state) => {
     return {
-        stories: state.get('stories'),
-        featuredStories: state.get('featuredStories')
+        stories: state.getIn(['stories','stories']),
+        featuredStories: state.getIn(['stories', 'featuredStories'])
     }
 };
 

--- a/app/scenes/StoryPlayer.js
+++ b/app/scenes/StoryPlayer.js
@@ -5,7 +5,6 @@ import Dimensions from 'Dimensions';
 import RNFetchBlob from 'react-native-fetch-blob'
 import Sound from 'react-native-sound';
 import { Actions } from 'react-native-router-flux';
-import { store } from '../index'
 import { formatDuration } from '../core/story_core'
 import { Colors, ThemeBorderColors, ThemeTintColors } from '../stylesheets/theme';
 import { randomProperty } from '../core/story_core'
@@ -104,7 +103,7 @@ class StoryPlayer extends Component {
         var id = setTimeout(()=> {
            Actions.popTo('Landing')
         }, 120000);
-        store.dispatch({type: 'SET_TIMEOUT_ID', timeoutId: id});
+        this.props.dispatch({type: 'SET_TIMEOUT_ID', timeoutId: id});
     }
 
 
@@ -249,7 +248,7 @@ const styles = {
 
 const mapStateToProps = (state) => {
     return {
-        stories: state.get('stories')
+        stories: state.getIn(['stories', 'stories'])
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-native-router-flux": "^3.37.0",
     "react-native-sound": "^0.8.3",
     "react-redux": "^4.4.6",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-immutable": "^4.0.0"
   },
   "jest": {
     "preset": "jest-react-native"


### PR DESCRIPTION
Matt, 

This was something I had worked on a while ago during an evening that I was also going to implement animations across the app, stored in the redux state. That whole idea (colors in state), didn't work out though, and I created another branch to start a color sequencer class that will take care of the sequences on it's own. 

In any case, I thought it would have been a good idea to use the redux-immutable combine reducers to keep our reducers smaller, this is a common redux pattern anyways. The one caveat is that there could be a performance issue... I haven't read anything online about the redux-immutable combineReducers being more memory intensive, and we did use this structure on ParkBark without a whole lot of increased lag, seemingly. 

Still, If you are able to check the indexing again and see an increase in performance, I would be fine not adding this structure. 

